### PR TITLE
feat: expose permissions as a Hash

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,4 +6,5 @@ group :development do
   gem 'rspec-core'
   gem 'rspec-expectations'
   gem 'rspec-mocks'
+  gem 'pry'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,12 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    coderay (1.1.3)
     diff-lcs (1.3)
+    method_source (1.1.0)
+    pry (0.14.1)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
     rspec (3.8.0)
       rspec-core (~> 3.8.0)
       rspec-expectations (~> 3.8.0)
@@ -20,6 +25,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  pry
   rspec
   rspec-core
   rspec-expectations

--- a/lib/checken/dsl/group_dsl.rb
+++ b/lib/checken/dsl/group_dsl.rb
@@ -36,6 +36,7 @@ module Checken
       def group(key, &block)
         sub_group = @group.groups[key.to_sym] || @group.add_group(key.to_sym)
         sub_group.dsl(:active_sets => active_sets, &block) if block_given?
+        sub_group.update_schema
         sub_group
       end
 
@@ -66,6 +67,7 @@ module Checken
         end
 
         permission.dsl(&block) if block_given?
+        permission.update_schema
         permission
       end
 

--- a/lib/checken/permission.rb
+++ b/lib/checken/permission.rb
@@ -295,5 +295,19 @@ module Checken
       end.flatten
     end
 
+    def update_schema
+      return if path.nil?
+
+      group.schema.update_schema(
+        {
+          path => {
+            type: :permission,
+            description: description,
+            group: group.path
+          }
+        }
+      )
+    end
+
   end
 end

--- a/lib/checken/permission_group.rb
+++ b/lib/checken/permission_group.rb
@@ -165,5 +165,20 @@ module Checken
       dsl
     end
 
+    def update_schema
+      return if path.nil?
+
+      schema.update_schema(
+        {
+          path => {
+            type: :group,
+            name: name,
+            description: description,
+            group: group&.path
+          }
+        }
+      )
+    end
+
   end
 end

--- a/lib/checken/schema.rb
+++ b/lib/checken/schema.rb
@@ -19,6 +19,7 @@ module Checken
     def initialize
       @root_group = PermissionGroup.new(self, nil)
       @config = Config.new
+      @schema = {}
     end
 
     # Add configuration for this schema
@@ -126,6 +127,21 @@ module Checken
     # @return [Logger]
     def logger
       @config.logger
+    end
+
+    # Update the schema with the given entry
+    #
+    # @param entry [Hash]
+    # @return [Hash]
+    def update_schema(entry)
+      @schema.merge!(entry)
+    end
+
+    # Return the schema sorted alphabetically by key
+    #
+    # @return [Hash]
+    def schema
+      @schema.sort.to_h
     end
 
   end

--- a/spec/specs/dsl/group_dsl_spec.rb
+++ b/spec/specs/dsl/group_dsl_spec.rb
@@ -66,25 +66,43 @@ describe Checken::DSL::GroupDSL do
     expect(schema.root_group[:delete].dependencies).to be_empty
   end
 
-  it "should reopen groups if they already have been defined" do
-    schema.root_group.dsl do
-      group :projects do
-        permission :list
-        group :edit do
-          permission :details
+  context 'when reopening groups' do
+    before do
+      schema.root_group.dsl do
+        group :projects do
+          permission :list
+          group :edit do
+            permission :details
+          end
         end
-      end
-      group :projects do
-        permission :view
-        group :edit do
-          permission :icon
+        group :projects do
+          permission :view
+          group :edit do
+            permission :icon
+          end
         end
       end
     end
-    expect(schema.root_group[:projects][:list]).to be_a Checken::Permission
-    expect(schema.root_group[:projects][:view]).to be_a Checken::Permission
-    expect(schema.root_group[:projects][:edit][:details]).to be_a Checken::Permission
-    expect(schema.root_group[:projects][:edit][:icon]).to be_a Checken::Permission
+
+    it "should reopen groups if they already have been defined" do
+      expect(schema.root_group[:projects][:list]).to be_a Checken::Permission
+      expect(schema.root_group[:projects][:view]).to be_a Checken::Permission
+      expect(schema.root_group[:projects][:edit][:details]).to be_a Checken::Permission
+      expect(schema.root_group[:projects][:edit][:icon]).to be_a Checken::Permission
+    end
+
+    it "should not add duplicate entries to the schema" do
+      expect(schema.schema).to eq(
+        {
+        "projects" => {description: nil, group: nil, name: nil, type: :group},
+        "projects.edit" => {description: nil, group: "projects", name: nil, type: :group},
+        "projects.edit.details" => {description: "projects.edit.details", group: "projects.edit", type: :permission},
+        "projects.edit.icon" => {description: "projects.edit.icon", group: "projects.edit", type: :permission},
+        "projects.list" => {description: "projects.list", group: "projects", type: :permission},
+        "projects.view" => {description: "projects.view", group: "projects", type: :permission},
+        }
+      )
+    end
   end
 
 end

--- a/spec/specs/permission_spec.rb
+++ b/spec/specs/permission_spec.rb
@@ -354,4 +354,68 @@ describe Checken::Permission do
     end
   end
 
+  describe "#update_schema" do
+    context "when the permission has no path" do
+      it "should not update the schema" do
+        permission = Checken::Permission.new(group, nil)
+        permission.update_schema
+        expect(permission.group.schema.schema).to eq({})
+      end
+    end
+
+    context "when a permission is added to the root group" do
+      it "should update the schema" do
+        permission = schema.root_group.add_permission(:change_password)
+        permission.description = "Change password"
+        permission.update_schema
+        expect(permission.group.schema.schema).to eq(
+          {
+            'change_password' => {
+              description: 'Change password',
+              group: nil,
+              type: :permission
+            }
+          }
+        )
+      end
+    end
+
+    context 'when a permission is added to a sub-group of the root group' do
+      it 'should update the schema' do
+        group1 = schema.root_group.add_group(:group1)
+        permission = group1.add_permission(:change_password)
+        permission.description = "Change password"
+        permission.update_schema
+        expect(permission.group.schema.schema).to eq(
+          {
+            'group1.change_password' => {
+              description: 'Change password',
+              group: 'group1',
+              type: :permission
+            }
+          }
+        )
+      end
+    end
+
+    context 'when a permission is added to a sub-group of a sub-group' do
+      it 'should update the schema' do
+        group1 = schema.root_group.add_group(:group1)
+        group2 = group1.add_group(:group2)
+        permission = group2.add_permission(:change_password)
+        permission.description = "Change password"
+        permission.update_schema
+        expect(permission.group.schema.schema).to eq(
+          {
+            'group1.group2.change_password' => {
+              description: 'Change password',
+              group: 'group1.group2',
+              type: :permission
+            }
+          }
+        )
+      end
+    end
+  end
+
 end


### PR DESCRIPTION
Add a new `Checken::Schema#schema` method for exposing the permissions as a Hash.

e.g.

```ruby
group :compute do
  name 'Compute'
  description 'These permissions relate to resources that are classified as compute.'

  group :virtual_machines do
    name 'Virtual machines'

    permission :view, 'List & view virtual machines'
  end
end
```

Will be formatted as:

```ruby
{
  "compute": {
    type: "group",
    name: "Compute",
    description: "These permissions relate to resources that are classified as compute"
  },
  "compute.virtual_machines":{
    type: "group",
    name: "Virtual Machines",
    description: nil,
    group: 'compute'
  },
  "compute.virtual_machines.view": {
    type: "permission",
    description: "List & view virtual machines",
    group: 'compute.virtual_machines'
  }
}
```

Note that groups have a `name` and a `description` but permission only has `description`.