### PR TITLE
feat: allow optional namespace configuration

### DIFF
--- a/lib/checken/concerns/has_parents.rb
+++ b/lib/checken/concerns/has_parents.rb
@@ -9,6 +9,13 @@ module Checken
         @key.nil? ? nil : [@group.path, @key].compact.join('.')
       end
 
+      # Return the full path to this permission with the namespace
+      #
+      # @return [String]
+      def path_with_namespace
+        [@schema.config.namespace, path].compact.join(@schema.config.namespace_delimiter)
+      end
+
       # Return the parents for ths group
       #
       # @return [Array<Checken::PermissionGroup, Checken::Permission>]

--- a/lib/checken/config.rb
+++ b/lib/checken/config.rb
@@ -4,6 +4,30 @@ require 'checken/user_proxy'
 module Checken
   class Config
 
+    DEFAULT_NAMESPACE_DELIMITER = ":"
+
+    # An optional namespace that will prefix all group and permission paths.
+    #
+    attr_accessor :namespace
+
+    # The delimiter that should be used to separate namespaces
+    # in group and permission paths.
+    #
+    # @return [String]
+    def namespace_delimiter
+      @namespace_delimiter ||= DEFAULT_NAMESPACE_DELIMITER
+    end
+    attr_writer :namespace_delimiter
+
+    # Should the namespace be optional when checking permissions?
+    # Defaults to false.
+    #
+    # @return [Boolean]
+    def namespace_optional?
+      @namespace_optional || false
+    end
+    attr_writer :namespace_optional
+
     # The class that should be used to create user proxies.
     #
     # @return [Class]

--- a/spec/specs/config_spec.rb
+++ b/spec/specs/config_spec.rb
@@ -1,0 +1,34 @@
+require 'spec_helper'
+require 'checken/config'
+
+RSpec.describe Checken::Config do
+
+  subject(:config) { Checken::Config.new }
+
+  describe "#namespace_delimiter" do
+    it "should return the default namespace delimiter" do
+      expect(config.namespace_delimiter).to eq ":"
+    end
+
+    context "when a custom delimiter is set" do
+      it "should return the custom delimiter" do
+        config.namespace_delimiter = "/"
+        expect(config.namespace_delimiter).to eq "/"
+      end
+    end
+  end
+
+  describe "#namespace" do
+    it "should return nil by default" do
+      expect(config.namespace).to be_nil
+    end
+
+    context "when a custom namespace is set" do
+      it "should return the custom namespace" do
+        config.namespace = "custom"
+        expect(config.namespace).to eq "custom"
+      end
+    end
+  end
+
+end


### PR DESCRIPTION
This PR allows the ability to specify an optional namespace for all groups and permissions. This is useful so that they are easily distinguishable between different applications.

e.g. "app1:users.edit" and "app2:users.edit"

The namespace is set as part of the config in the initializer in the Rails application.

```ruby
Checken::Schema.instance.configure do |config|
  config.namespace = 'app1'
end
```

> [!NOTE]
> Additional details of namespace configuration are in the README.md